### PR TITLE
基本機能実装 - 管理人画像選択とPNGダウンロード

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@mantine/form": "^8.2.4",
         "@mantine/hooks": "^8.2.4",
         "@tabler/icons-react": "^3.34.1",
-        "@types/html2canvas": "^0.5.35",
         "html2canvas": "^1.4.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
@@ -22,6 +21,7 @@
       "devDependencies": {
         "@eslint/js": "^9.30.1",
         "@tailwindcss/postcss": "^4.1.11",
+        "@types/html2canvas": "^0.5.35",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
@@ -1870,6 +1870,7 @@
       "version": "0.5.35",
       "resolved": "https://registry.npmjs.org/@types/html2canvas/-/html2canvas-0.5.35.tgz",
       "integrity": "sha512-1A2dtWZbOIZ+rUK8jmAx1We/EiNV+5vScpphU3AF14Vby6COIazi/9StosrvlVCqlQegRhsEgZf7QYOuWbwuuA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/jquery": "*"
@@ -1879,6 +1880,7 @@
       "version": "3.5.32",
       "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.32.tgz",
       "integrity": "sha512-b9Xbf4CkMqS02YH8zACqN1xzdxc3cO735Qe5AbSUFmyOiaWAbcpqh9Wna+Uk0vgACvoQHpWDg2rGdHkYPLmCiQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/sizzle": "*"
@@ -1915,6 +1917,7 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.9.tgz",
       "integrity": "sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@mantine/form": "^8.2.4",
     "@mantine/hooks": "^8.2.4",
     "@tabler/icons-react": "^3.34.1",
-    "@types/html2canvas": "^0.5.35",
     "html2canvas": "^1.4.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
@@ -24,6 +23,7 @@
   "devDependencies": {
     "@eslint/js": "^9.30.1",
     "@tailwindcss/postcss": "^4.1.11",
+    "@types/html2canvas": "^0.5.35",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",


### PR DESCRIPTION
## Summary

  WordPress管理者が登録した画像から選択してカスタマイズ・PNG出力する基本機
  能を実装しました。

  ### 📋 実装内容

  - ✅ **ドラッグ&ドロップ機能削除**:
  既存のDropzone画像アップロード機能を完全削除
  - ✅ **管理者画像選択機能**:
  WordPress管理者が事前登録した画像一覧から選択するUI
  - ✅ **サムネイル一覧表示**: レスポンシブなグリッド表示と選択状態表示
  - ✅ **PNG高品質ダウンロード**: html2canvas使用で2倍解像度出力対応
  - ✅ **既存機能維持**: 色選択・形状変更・サイズ調整の全機能継続

  ### 🎨 UI/UX改善

  - **画像選択インターフェース**: 6枚のモック画像をサムネイル表示
  - **ホバーエフェクト**: 画像選択時の視覚的フィードバック
  - **スライドツールパネル**: 下部からのスムーズなアニメーション
  - **カラーピッカー**: 右サイドパネルでカスタム色選択

  ### 🔧 技術仕様

  - **html2canvas**: 1.4.1 + CORS対応で外部画像対応
  - **TypeScript**: 厳密な型定義でエラーゼロ
  - **Mantine UI**: v8.2.4 継続使用
  - **ESLint/Build**: 全チェック通過済み

  ### 📱 動作確認

  - [x] 画像選択: 6種類のモック画像から選択可能
  - [x] カスタマイズ: 色・形状・サイズ調整正常動作
  - [x] PNG出力: 高解像度ダウンロード成功
  - [x] レスポンシブ: 各種デバイスサイズ対応

  ### 🚀 WordPress統合準備

  Phase 2でWordPress管理画面統合予定：
  - WordPress REST API経由での画像管理
  - 管理者向け画像登録・削除・編集機能
  - エンドユーザー向けショートコード埋め込み