### PR TITLE
🎨 UIデバッグログ要素を削除: コンソールログのみに限定

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,8 +17,6 @@ const rootInstances = new Map<string, ReturnType<typeof createRoot>>();
 
 // 複数のIcon Customizerインスタンスを初期化
 function initializeIconCustomizers() {
-  console.log('🚀 Icon Customizer: 初期化関数開始');
-  
   // 新しい複数インスタンス形式をチェック
   if (window.ICON_EDITOR_INSTANCES) {
     Object.entries(window.ICON_EDITOR_INSTANCES).forEach(([instanceId, config]) => {
@@ -26,7 +24,6 @@ function initializeIconCustomizers() {
       if (container) {
         // 既にrootが作成されているかチェック
         if (!rootInstances.has(instanceId)) {
-          console.log(`✨ Icon Customizer: 新しいroot作成 (${instanceId})`);
           const root = createRoot(container);
           rootInstances.set(instanceId, root);
           
@@ -36,7 +33,6 @@ function initializeIconCustomizers() {
             </StrictMode>
           );
         } else {
-          console.log(`♻️ Icon Customizer: 既存root再利用 (${instanceId})`);
           const root = rootInstances.get(instanceId)!;
           root.render(
             <StrictMode>
@@ -44,8 +40,6 @@ function initializeIconCustomizers() {
             </StrictMode>
           );
         }
-      } else {
-        console.warn(`❌ Icon Customizer: コンテナが見つかりません (${instanceId})`);
       }
     });
   }
@@ -53,7 +47,6 @@ function initializeIconCustomizers() {
   else if (window.ICON_EDITOR_CONFIG) {
     const container = document.getElementById('root');
     if (container && !rootInstances.has('root')) {
-      console.log('✨ Icon Customizer: 旧式root作成');
       const root = createRoot(container);
       rootInstances.set('root', root);
       root.render(
@@ -67,7 +60,6 @@ function initializeIconCustomizers() {
   else {
     const container = document.getElementById('root');
     if (container && !rootInstances.has('root')) {
-      console.log('✨ Icon Customizer: 開発環境root作成');
       const root = createRoot(container);
       rootInstances.set('root', root);
       root.render(
@@ -82,30 +74,19 @@ function initializeIconCustomizers() {
 // 初期化実行状況を管理
 let initializationAttempted = false;
 
-// WordPress環境での確実な初期化（デバッグ強化版）
+// WordPress環境での確実な初期化
 function tryInitialize() {
-  console.log('🔍 Icon Customizer: 初期化試行開始', {
-    readyState: document.readyState,
-    hasInstances: !!(window.ICON_EDITOR_INSTANCES),
-    instanceCount: window.ICON_EDITOR_INSTANCES ? Object.keys(window.ICON_EDITOR_INSTANCES).length : 0,
-    attempted: initializationAttempted,
-    timestamp: new Date().toISOString()
-  });
-  
   // インスタンス設定が存在するかチェック
   if (window.ICON_EDITOR_INSTANCES && Object.keys(window.ICON_EDITOR_INSTANCES).length > 0) {
     if (!initializationAttempted) {
-      console.log('✅ Icon Customizer: インスタンス設定発見、初期化開始', window.ICON_EDITOR_INSTANCES);
       initializationAttempted = true;
       initializeIconCustomizers();
       return true;
     } else {
-      console.log('⚠️ Icon Customizer: 既に初期化済み、スキップ');
       return true;
     }
   }
   
-  console.log('⏳ Icon Customizer: インスタンス設定待機中...');
   return false;
 }
 


### PR DESCRIPTION
- main.tsx内の不要なconsole.logステートメントを削除
- UIに表示されていたデバッグ情報を除去
- Icon Customizerの機能は維持したまま表示をクリーン化
